### PR TITLE
[source-facebook-marketing] Add one word to make logs more clear about utilization

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/api.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/api.py
@@ -128,7 +128,7 @@ class MyFacebookAdsApi(FacebookAdsApi):
 
         if usage >= self.MIN_RATE:
             sleep_time = self._compute_pause_interval(usage=usage, pause_interval=pause_interval)
-            logger.warning(f"Utilization is too high ({usage})%, pausing for {sleep_time}")
+            logger.warning(f"API Utilization is too high ({usage})%, pausing for {sleep_time}")
             sleep(sleep_time.total_seconds())
 
     def _update_insights_throttle_limit(self, response: FacebookResponse):


### PR DESCRIPTION
## What

One more word about utilization type.

There were some questions about this warning:
https://airbytehq.slack.com/archives/C021JANJ6TY/p1739242111784099
https://airbytehq.slack.com/archives/C021JANJ6TY/p1734513075065149

## How

Just added one word 😉 

## Review guide

1. `airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/api.py`

## User Impact

Tiny, but it helps people to know what this warning is all about.

## Can this PR be safely reverted and rolled back?

- [x] YES 💚
- [ ] NO ❌
